### PR TITLE
[FEAT]: add message of the day API endpoints

### DIFF
--- a/src/main/java/com/madani/devops_api/DevopsApiApplication.java
+++ b/src/main/java/com/madani/devops_api/DevopsApiApplication.java
@@ -4,22 +4,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*; // Importer tout pour POST/RequestBody
 
 @SpringBootApplication
 @RestController
 public class DevopsApiApplication {
-	private static final Logger logger = LoggerFactory.getLogger(DevopsApiApplication.class);
+    private static final Logger logger = LoggerFactory.getLogger(DevopsApiApplication.class);
+    
+    // NOUVEAU : Une variable pour stocker un état (mémoire vive)
+    private String messageDuJour = "Bienvenue sur l'API DevOps (Message par défaut)";
 
-	public static void main(String[] args) {
-		SpringApplication.run(DevopsApiApplication.class, args);
-	}
-	
-	
-	@GetMapping("/")
+    public static void main(String[] args) {
+        SpringApplication.run(DevopsApiApplication.class, args);
+    }
+    
+    @GetMapping("/")
     public String home() {
-        logger.info("Accès à la page d'accueil"); // Log structuré simple
+        logger.info("Accès à la page d'accueil");
         return "Bienvenue sur mon projet DevOps !";
     }
 
@@ -28,12 +29,25 @@ public class DevopsApiApplication {
         logger.info("Requête reçue sur /api/hello");
         return "Bonjour le monde ! Ceci est mon API REST.";
     }
+    
+    
+    @GetMapping("/api/message")
+    public String getMessage() {
+        logger.info("Lecture du message du jour");
+        return this.messageDuJour;
+    }
+
+ 
+    @PostMapping("/api/message")
+    public String updateMessage(@RequestBody String newMessage) {
+        logger.info("Mise à jour du message : ancien='{}', nouveau='{}'", this.messageDuJour, newMessage);
+        this.messageDuJour = newMessage;
+        return "Message mis à jour avec succès !";
+    }
 
     @GetMapping("/api/error")
     public String triggerError() {
         logger.error("Oups! Une erreur a été déclenchée volontairement.");
         throw new RuntimeException("Erreur de test DevOps");
     }
-	
-
 }


### PR DESCRIPTION
This PR adds a new feature to store and retrieve a daily message. Changes:

- Added GET /api/message

- Added POST /api/message

- Included structured logging.

Closes #2 